### PR TITLE
org: Add nursery for unmaintained projects

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,6 +30,21 @@ This means, by default, they have administrative power over the organization, in
 Maintainers have full control over their respective projects and teams.
 If you would like to **add a new project** to the organization please see [Getting Involved](CONTRIBUTING.md#getting-involved).
 
+### Nursery
+When a transfer request is completed for an unmaintained project, it is automatically placed under governance of the [@typst-community/nursery] team.
+
+Every member of this team may triage issues, merge PRs, or create releases for such a project.
+The extent of work put into the maintenance of such a project is up to each member of the team.
+Nursery maintenance typically means minimum maintenance until a new maintainer is found, this means that bugs are fixed, but features may not be implemented.
+
+If an active collaborator of such a project is willing to take over maintenance of the project the Nursery team will invite them to the organization to add them as a maintainer.
+After some time the Nursery team may decide to down from the project and fully transferring governance to the new maintainer.
+Such a transfer will (where possible) be done in accordance with the original maintainer.
+
+Ownership transfers from and to the Nursery team may be announced to let the community and the Typst team know about the change in maintainers.
+This way no issues should arise when new versions of packages are being published to the Typst Universe by the new maintainers.
+
+
 [@bluss]: https://github.com/bluss
 [@huwaireb]: https://github.com/huwaireb
 [@jcbhmr]: https://github.com/jcbhmr
@@ -39,8 +54,9 @@ If you would like to **add a new project** to the organization please see [Getti
 [@tingerrr]: https://github.com/tingerrr
 [@yusancky]: https://github.com/yusancky
 
-[@typst-community/setup-typst]: https://github.com/orgs/typst-community/teams/setup-typst
 [@typst-community/ecosystem]: https://github.com/orgs/typst-community/teams/ecosystem
+[@typst-community/nursery]: https://github.com/orgs/typst-community/teams/setup-typst
+[@typst-community/setup-typst]: https://github.com/orgs/typst-community/teams/setup-typst
 
 [glossarium]: https://github.com/typst-community/glossarium
 [setup-hayagriva]: https://github.com/typst-community/setup-hayagriva

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ These communities in question are the [coq-community](https://github.com/coq-com
 ### What are its goals?
 We follow, in essence, the same goals as the other communities. Namely:
 
-#### Collaborative maintenance of Typst packages and tools
-We aim to provide a central location for the maintenance of Typst packages and tools. 
+#### Collaborative maintenance of Typst projects
+We aim to provide a central location for the maintenance of Typst projects.
 
 Projects can be hosted in typst-community whenever any of the following is the case:
 - **The** author stopped maintaining the project.
+  - Projects which are unmaintaned are placed under governance of the Nursery team, see [GOVERNANCE.md](GOVERNANCE.md#Nursery).
 - **The** project has become a collective work, as several community members are actively working on it.
 - **The** author is still maintaining the project but they want to encourage other community members to participate in its maintenance and possibly take over.
 - **The** project is a tool of general interest and it makes sense to develop it collaboratively.


### PR DESCRIPTION
Left this in draft because I want to discuss scope and feasibility first. We currently have adopted two unmaintained projects:
- https://github.com/typst-community/valkyrie
- https://github.com/typst-community/harbinger

I've personally taken up nursery for valkyrie before the transfer, this includes mostly fixing bugs while it's unmaintained. I would like to use a team to add others who are willing to help and to make permission management easier. The PR adds a repo for this, but we might not need that.